### PR TITLE
[PR-6] Add Caching and related test

### DIFF
--- a/src/main/java/org/service/brandcody/config/CacheConfig.java
+++ b/src/main/java/org/service/brandcody/config/CacheConfig.java
@@ -1,0 +1,52 @@
+package org.service.brandcody.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    public static final String BRAND_CACHE = "brandCache";
+    public static final String BRAND_BY_ID_CACHE = "brandByIdCache";
+    public static final String BRAND_BY_NAME_CACHE = "brandByNameCache";
+    public static final String PRODUCT_CACHE = "productCache";
+    public static final String PRODUCT_BY_ID_CACHE = "productByIdCache";
+    public static final String PRODUCTS_BY_BRAND_CACHE = "productsByBrandCache";
+    public static final String PRODUCT_BY_BRAND_CATEGORY_CACHE = "productByBrandCategoryCache";
+    public static final String LOWEST_PRICE_BY_CATEGORY_CACHE = "lowestPriceByCategoryCache";
+    public static final String HIGHEST_PRICE_BY_CATEGORY_CACHE = "highestPriceByCategoryCache";
+    public static final String LOWEST_PRICE_BRAND_CACHE = "lowestPriceBrandCache";
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+
+        cacheManager.setCacheNames(Arrays.asList(
+            BRAND_CACHE, 
+            BRAND_BY_ID_CACHE, 
+            BRAND_BY_NAME_CACHE,
+            PRODUCT_CACHE, 
+            PRODUCT_BY_ID_CACHE, 
+            PRODUCTS_BY_BRAND_CACHE,
+            PRODUCT_BY_BRAND_CATEGORY_CACHE,
+            LOWEST_PRICE_BY_CATEGORY_CACHE,
+            HIGHEST_PRICE_BY_CATEGORY_CACHE,
+            LOWEST_PRICE_BRAND_CACHE
+        ));
+
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+            .expireAfterWrite(5, TimeUnit.MINUTES)
+            .maximumSize(1000)
+            .recordStats());
+        
+        return cacheManager;
+    }
+}

--- a/src/main/java/org/service/brandcody/service/BrandService.java
+++ b/src/main/java/org/service/brandcody/service/BrandService.java
@@ -2,9 +2,13 @@ package org.service.brandcody.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.service.brandcody.config.CacheConfig;
 import org.service.brandcody.domain.Brand;
 import org.service.brandcody.dto.BrandTotalProjection;
 import org.service.brandcody.repository.BrandRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -23,22 +27,33 @@ import java.util.NoSuchElementException;
 public class BrandService {
     private final BrandRepository brandRepository;
 
+    @Cacheable(CacheConfig.BRAND_CACHE)
     public List<Brand> getAllBrands() {
+        log.debug("Fetching all brands from database");
         return brandRepository.findAll();
     }
 
+    @Cacheable(value = CacheConfig.BRAND_BY_ID_CACHE, key = "#id")
     public Brand getBrandById(Long id) {
+        log.debug("Fetching brand with id: {}", id);
         return brandRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("Brand not found with id: " + id));
     }
 
+    @Cacheable(value = CacheConfig.BRAND_BY_NAME_CACHE, key = "#name")
     public Brand getBrandByName(String name) {
+        log.debug("Fetching brand with name: {}", name);
         return brandRepository.findByName(name)
                 .orElseThrow(() -> new NoSuchElementException("Brand not found with name: " + name));
     }
 
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfig.BRAND_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.LOWEST_PRICE_BRAND_CACHE, allEntries = true)
+    })
     public Brand createBrand(String name) {
+        log.debug("Creating new brand with name: {}", name);
         try {
             Brand brand = new Brand();
             brand.setName(name);
@@ -55,6 +70,12 @@ public class BrandService {
         backoff = @Backoff(delay = 500)
     )
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfig.BRAND_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.BRAND_BY_ID_CACHE, key = "#id"),
+        @CacheEvict(value = CacheConfig.BRAND_BY_NAME_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.LOWEST_PRICE_BRAND_CACHE, allEntries = true)
+    })
     public Brand updateBrand(Long id, String name) {
         log.debug("Attempting to update brand with id: {} to name: {}", id, name);
         Brand brand = getBrandById(id);
@@ -77,6 +98,13 @@ public class BrandService {
         backoff = @Backoff(delay = 500)
     )
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfig.BRAND_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.BRAND_BY_ID_CACHE, key = "#id"),
+        @CacheEvict(value = CacheConfig.BRAND_BY_NAME_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.LOWEST_PRICE_BRAND_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.PRODUCTS_BY_BRAND_CACHE, key = "#id")
+    })
     public void deleteBrand(Long id) {
         log.debug("Attempting to delete brand with id: {}", id);
         Brand brand = getBrandById(id);
@@ -88,7 +116,9 @@ public class BrandService {
         }
     }
 
+    @Cacheable(CacheConfig.LOWEST_PRICE_BRAND_CACHE)
     public BrandTotalProjection findBrandWithLowestTotalPrice() {
+        log.debug("Calculating brand with lowest total price");
         List<BrandTotalProjection> result = brandRepository.findBrandWithLowestTotalPrice(PageRequest.of(0, 1));
         
         if (result.isEmpty()) {
@@ -98,7 +128,9 @@ public class BrandService {
         return result.getFirst();
     }
 
+    @Cacheable(CacheConfig.BRAND_CACHE)
     public List<BrandTotalProjection> findAllBrandsWithTotalPrice() {
+        log.debug("Fetching all brands with total price");
         return brandRepository.findAllBrandsWithTotalPrice();
     }
 }

--- a/src/main/java/org/service/brandcody/service/ProductService.java
+++ b/src/main/java/org/service/brandcody/service/ProductService.java
@@ -2,12 +2,16 @@ package org.service.brandcody.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.service.brandcody.config.CacheConfig;
 import org.service.brandcody.domain.Brand;
 import org.service.brandcody.domain.Category;
 import org.service.brandcody.domain.Product;
 import org.service.brandcody.dto.CategoryBrandPriceDto;
 import org.service.brandcody.repository.BrandRepository;
 import org.service.brandcody.repository.ProductRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
@@ -27,25 +31,42 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final BrandRepository brandRepository;
 
+    @Cacheable(CacheConfig.PRODUCT_CACHE)
     public List<Product> getAllProducts() {
+        log.debug("Fetching all products from database");
         return productRepository.findAll();
     }
 
+    @Cacheable(value = CacheConfig.PRODUCT_BY_ID_CACHE, key = "#id")
     public Product getProductById(Long id) {
+        log.debug("Fetching product with id: {}", id);
         return productRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("Product not found with id: " + id));
     }
 
+    @Cacheable(value = CacheConfig.PRODUCTS_BY_BRAND_CACHE, key = "#brandId")
     public List<Product> getProductsByBrand(Long brandId) {
+        log.debug("Fetching products for brand id: {}", brandId);
         return productRepository.findByBrandIdOrderByCategory(brandId);
     }
 
+    @Cacheable(value = CacheConfig.PRODUCT_BY_BRAND_CATEGORY_CACHE, key = "#brandId + '-' + #category.name()")
     public Optional<Product> getProductByBrandAndCategory(Long brandId, Category category) {
+        log.debug("Fetching product for brand id: {} and category: {}", brandId, category);
         return productRepository.findByBrandIdAndCategory(brandId, category);
     }
 
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfig.PRODUCT_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.PRODUCTS_BY_BRAND_CACHE, key = "#brandId"),
+        @CacheEvict(value = CacheConfig.PRODUCT_BY_BRAND_CATEGORY_CACHE, key = "#brandId + '-' + #category.name()"),
+        @CacheEvict(value = CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.HIGHEST_PRICE_BY_CATEGORY_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.LOWEST_PRICE_BRAND_CACHE, allEntries = true)
+    })
     public Product createProduct(Long brandId, Category category, Integer price) {
+        log.debug("Creating new product for brand id: {} and category: {} with price: {}", brandId, category, price);
         Brand brand = brandRepository.findById(brandId)
                 .orElseThrow(() -> new NoSuchElementException("Brand not found with id: " + brandId));
 
@@ -65,6 +86,15 @@ public class ProductService {
         backoff = @Backoff(delay = 500)
     )
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfig.PRODUCT_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.PRODUCT_BY_ID_CACHE, key = "#id"),
+        @CacheEvict(value = CacheConfig.PRODUCTS_BY_BRAND_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.PRODUCT_BY_BRAND_CATEGORY_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.HIGHEST_PRICE_BY_CATEGORY_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.LOWEST_PRICE_BRAND_CACHE, allEntries = true)
+    })
     public Product updateProduct(Long id, Integer price) {
         log.debug("Attempting to update product with id: {} to price: {}", id, price);
         Product product = getProductById(id);
@@ -83,6 +113,14 @@ public class ProductService {
         backoff = @Backoff(delay = 500)
     )
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfig.PRODUCT_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.PRODUCTS_BY_BRAND_CACHE, key = "#brandId"),
+        @CacheEvict(value = CacheConfig.PRODUCT_BY_BRAND_CATEGORY_CACHE, key = "#brandId + '-' + #category.name()"),
+        @CacheEvict(value = CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE, key = "#category.name()"),
+        @CacheEvict(value = CacheConfig.HIGHEST_PRICE_BY_CATEGORY_CACHE, key = "#category.name()"),
+        @CacheEvict(value = CacheConfig.LOWEST_PRICE_BRAND_CACHE, allEntries = true)
+    })
     public Product updateProductByBrandAndCategory(Long brandId, Category category, Integer price) {
         log.debug("Attempting to update product for brand id: {} and category: {} to price: {}", brandId, category, price);
         Product product = productRepository.findByBrandIdAndCategory(brandId, category)
@@ -105,6 +143,15 @@ public class ProductService {
         backoff = @Backoff(delay = 500)
     )
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfig.PRODUCT_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.PRODUCT_BY_ID_CACHE, key = "#id"),
+        @CacheEvict(value = CacheConfig.PRODUCTS_BY_BRAND_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.PRODUCT_BY_BRAND_CATEGORY_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.HIGHEST_PRICE_BY_CATEGORY_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfig.LOWEST_PRICE_BRAND_CACHE, allEntries = true)
+    })
     public void deleteProduct(Long id) {
         log.debug("Attempting to delete product with id: {}", id);
         Product product = getProductById(id);
@@ -118,19 +165,27 @@ public class ProductService {
         }
     }
 
+    @Cacheable(CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE)
     public List<CategoryBrandPriceDto> findLowestPriceByAllCategories() {
+        log.debug("Calculating lowest price for all categories");
         return productRepository.findLowestPriceByCategory();
     }
 
+    @Cacheable(value = CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE, key = "#category.name()")
     public List<CategoryBrandPriceDto> findLowestPriceByCategory(Category category) {
+        log.debug("Calculating lowest price for category: {}", category);
         return productRepository.findLowestPriceByCategory(category);
     }
 
+    @Cacheable(value = CacheConfig.HIGHEST_PRICE_BY_CATEGORY_CACHE, key = "#category.name()")
     public List<CategoryBrandPriceDto> findHighestPriceByCategory(Category category) {
+        log.debug("Calculating highest price for category: {}", category);
         return productRepository.findHighestPriceByCategory(category);
     }
 
+    @Cacheable(CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE)
     public int calculateTotalLowestPriceAcrossCategories() {
+        log.debug("Calculating total lowest price across all categories");
         List<CategoryBrandPriceDto> lowestPriceItems = findLowestPriceByAllCategories();
         return lowestPriceItems.stream()
                 .mapToInt(CategoryBrandPriceDto::getPrice)

--- a/src/test/java/org/service/brandcody/integration/ConcurrencyTest.java
+++ b/src/test/java/org/service/brandcody/integration/ConcurrencyTest.java
@@ -8,24 +8,32 @@ import org.service.brandcody.domain.Category;
 import org.service.brandcody.domain.Product;
 import org.service.brandcody.repository.BrandRepository;
 import org.service.brandcody.repository.ProductRepository;
+import org.service.brandcody.service.BrandService;
 import org.service.brandcody.service.ProductService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
@@ -44,6 +52,9 @@ public class ConcurrencyTest {
     
     @Autowired
     private ProductService productService;
+    
+    @Autowired
+    private BrandService brandService;
 
     private Brand testBrand;
     private Long brandId;
@@ -130,19 +141,19 @@ public class ConcurrencyTest {
         executorService.shutdown();
 
         // 1. 모든 스레드가 제한 시간 내에 종료되었는지 확인
-        assertThat(completed).as("All threads should complete within the timeout").isTrue();
+        assertThat(completed).as("모든 스레드가 타임아웃 시간 내에 완료되어야 함").isTrue();
         
         // 2. 데이터베이스 상태 검증: 해당 브랜드-카테고리 조합의 상품이 정확히 하나만 존재해야 함
         long productCount = productRepository.countByBrandIdAndCategory(brandId, Category.TOP);
-        assertThat(productCount).as("Only one product should exist for the brand-category combination").isEqualTo(1);
+        assertThat(productCount).as("브랜드-카테고리 조합에 대해 하나의 상품만 존재해야 함").isEqualTo(1);
         
         // 3. 검증: 요청이 정확히 2개 처리됨 (성공 1개 + 실패 1개)
         int total = successCount.get() + failureCount.get();
-        assertThat(total).as("Total requests processed should be 2").isEqualTo(2);
+        assertThat(total).as("총 처리된 요청은 2개여야 함").isEqualTo(2);
         
         // 4. 성공 1개, 실패 1개 검증
-        assertThat(successCount.get()).as("Successfully created products should be 1").isEqualTo(1);
-        assertThat(failureCount.get()).as("Failed creation attempts should be 1").isEqualTo(1);
+        assertThat(successCount.get()).as("성공적으로 생성된 상품은 1개여야 함").isEqualTo(1);
+        assertThat(failureCount.get()).as("실패한 생성 시도는 1개여야 함").isEqualTo(1);
     }
     
     @Test
@@ -227,16 +238,221 @@ public class ConcurrencyTest {
         
         // 검증
         // 1. 모든 스레드가 제한 시간 내에 종료되었는지 확인
-        assertThat(completed).as("All threads should complete within the timeout").isTrue();
+        assertThat(completed).as("모든 스레드가 타임아웃 시간 내에 완료되어야 함").isTrue();
         
         // 2. 두 요청 모두 성공했는지 확인 (재시도를 통해)
-        assertThat(successCount.get()).as("Both update operations should succeed due to retry").isEqualTo(2);
-        assertThat(failureCount.get()).as("No failures should occur with retry").isEqualTo(0);
+        assertThat(successCount.get()).as("재시도 덕분에 두 업데이트 작업 모두 성공해야 함").isEqualTo(2);
+        assertThat(failureCount.get()).as("재시도로 인해 실패가 발생하지 않아야 함").isEqualTo(0);
         
         // 3. 최신 상품 정보 확인
         Product updatedProduct = productRepository.findById(productId).orElseThrow();
         // 둘 중 하나의 가격이 적용되어 있어야 함
-        assertThat(updatedProduct.getPrice()).as("Product price should be updated to one of the values")
+        assertThat(updatedProduct.getPrice()).as("상품 가격이 두 값 중 하나로 업데이트되어야 함")
                 .isIn(15000, 20000);
+    }
+    
+    @Test
+    @DisplayName("서비스 계층에서 브랜드 동시 수정 낙관적 락 테스트")
+    void brandServiceOptimisticLockingTest() throws Exception {
+        // 테스트 데이터 준비
+        final String initialName = "ServiceConcurrencyTest";
+        final String newName1 = "UpdatedBrand1";
+        final String newName2 = "UpdatedBrand2";
+        
+        // 브랜드 생성
+        Brand brand = brandService.createBrand(initialName);
+        Long brandId = brand.getId();
+        
+        // 스레드 동기화를 위한 래치
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(2);
+        
+        // 결과 추적을 위한 Atomic 변수들
+        final AtomicBoolean firstThreadSuccess = new AtomicBoolean(false);
+        final AtomicBoolean secondThreadSuccess = new AtomicBoolean(false);
+        final AtomicReference<Exception> firstThreadException = new AtomicReference<>();
+        final AtomicReference<Exception> secondThreadException = new AtomicReference<>();
+        
+        // 스레드 풀 생성
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        
+        // 첫 번째 스레드: 브랜드명 업데이트 1
+        executorService.submit(() -> {
+            try {
+                startLatch.await(); // 메인 스레드가 시작 신호를 줄 때까지 대기
+                Thread.sleep(10); // 두 번째 스레드보다 약간 늦게 시작
+                
+                Brand updatedBrand = brandService.updateBrand(brandId, newName1);
+                firstThreadSuccess.set(true);
+            } catch (Exception e) {
+                firstThreadException.set(e);
+            } finally {
+                endLatch.countDown();
+            }
+        });
+        
+        // 두 번째 스레드: 브랜드명 업데이트 2
+        executorService.submit(() -> {
+            try {
+                startLatch.await(); // 메인 스레드가 시작 신호를 줄 때까지 대기
+                
+                Brand updatedBrand = brandService.updateBrand(brandId, newName2);
+                secondThreadSuccess.set(true);
+            } catch (Exception e) {
+                secondThreadException.set(e);
+            } finally {
+                endLatch.countDown();
+            }
+        });
+        
+        // 두 스레드를 동시에 시작
+        startLatch.countDown();
+        
+        // 모든 스레드가 완료될 때까지 대기 (최대 10초)
+        boolean completed = endLatch.await(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+        
+        // 검증
+        // 1. 모든 스레드가 제한 시간 내에 종료되었는지 확인
+        assertThat(completed).as("모든 스레드가 타임아웃 시간 내에 완료되어야 함").isTrue();
+        
+        // 2. 두 스레드 중 하나만 성공해야 함 (낙관적 락 + 재시도)
+        assertThat(firstThreadSuccess.get() || secondThreadSuccess.get())
+            .as("적어도 하나의 스레드가 성공해야 함")
+            .isTrue();
+        
+        // 3. 최종 브랜드명 확인
+        Brand finalBrand = brandRepository.findById(brandId).orElseThrow();
+        assertThat(finalBrand.getName()).as("브랜드 이름이 새로운 이름 중 하나로 업데이트되어야 함")
+            .isIn(newName1, newName2);
+    }
+    
+    @Test
+    @DisplayName("서비스 메소드에서 낙관적 락 예외 발생 및 처리 테스트")
+    void optimisticLockingExceptionHandlingTest() throws Exception {
+        // 상품 생성
+        Product product = productService.createProduct(brandId, Category.PANTS, 10000);
+        Long productId = product.getId();
+        
+        // 첫 번째 트랜잭션에서 상품 조회 (버전 로드)
+        Product product1 = productRepository.findById(productId).orElseThrow();
+        
+        // 두 번째 트랜잭션에서 상품 수정 (버전 증가)
+        Product product2 = productService.updateProduct(productId, 15000);
+        
+        // 첫 번째 트랜잭션의 엔티티로 수정 시도 (이미 버전이 증가되어 있으므로 실패해야 함)
+        // 이 테스트를 위해 재시도가 없는 직접적인 저장 작업 수행
+        product1.updatePrice(20000);
+        
+        // 낙관적 락 예외가 발생해야 함
+        assertThrows(ObjectOptimisticLockingFailureException.class, () -> {
+            productRepository.saveAndFlush(product1);
+        });
+        
+        // 최종 상태 확인 - 두 번째 트랜잭션의 가격이 유지되어야 함
+        Product finalProduct = productRepository.findById(productId).orElseThrow();
+        assertThat(finalProduct.getPrice()).as("성공한 트랜잭션의 가격인 15000이 유지되어야 함")
+            .isEqualTo(15000);
+        assertThat(finalProduct.getVersion()).as("버전이 증가되어야 함")
+            .isEqualTo(1);
+    }
+    
+    @Test
+    @DisplayName("다중 사용자가 동시에 최저가 조회 및 업데이트하는 시나리오 테스트")
+    void multipleUsersPerformingConcurrentOperationsTest() throws Exception {
+        // 테스트 준비: 여러 브랜드와 상품 생성
+        final int brandCount = 3;
+        final int threadCount = 10;
+        final List<Long> brandIds = new ArrayList<>();
+        final List<Long> productIds = new ArrayList<>();
+        
+        // 테스트 브랜드 및 상품 생성
+        for (int i = 0; i < brandCount; i++) {
+            Brand brand = brandService.createBrand("ConcurrentBrand" + i);
+            brandIds.add(brand.getId());
+            
+            // 각 브랜드에 여러 카테고리의 상품 추가
+            for (Category category : Category.values()) {
+                int price = 10000 + (i * 1000) + (category.ordinal() * 100);
+                Product product = productService.createProduct(brand.getId(), category, price);
+                productIds.add(product.getId());
+            }
+        }
+        
+        // 스레드 동기화를 위한 래치
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(threadCount);
+        
+        // 성공/실패/예외 카운터
+        final AtomicInteger readSuccessCount = new AtomicInteger(0);
+        final AtomicInteger writeSuccessCount = new AtomicInteger(0);
+        final AtomicInteger exceptionCount = new AtomicInteger(0);
+        
+        // 스레드 풀 생성
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        
+        // 여러 스레드가 동시에 다양한 작업을 수행
+        for (int i = 0; i < threadCount; i++) {
+            final int threadIndex = i;
+            executorService.submit(() -> {
+                try {
+                    startLatch.await(); // 모든 스레드가 준비될 때까지 대기
+                    
+                    // 스레드마다 랜덤하게 다른 작업 수행
+                    int operationType = ThreadLocalRandom.current().nextInt(4);
+                    switch (operationType) {
+                        case 0: // 최저가 조회
+                            productService.findLowestPriceByAllCategories();
+                            readSuccessCount.incrementAndGet();
+                            break;
+                            
+                        case 1: // 브랜드 정보 업데이트
+                            Long randomBrandId = brandIds.get(ThreadLocalRandom.current().nextInt(brandIds.size()));
+                            brandService.updateBrand(randomBrandId, "UpdatedBrand" + threadIndex);
+                            writeSuccessCount.incrementAndGet();
+                            break;
+                            
+                        case 2: // 상품 가격 업데이트
+                            Long randomProductId = productIds.get(ThreadLocalRandom.current().nextInt(productIds.size()));
+                            int newPrice = 5000 + ThreadLocalRandom.current().nextInt(20000);
+                            productService.updateProduct(randomProductId, newPrice);
+                            writeSuccessCount.incrementAndGet();
+                            break;
+                            
+                        case 3: // 특정 카테고리 최저가 브랜드 조회
+                            Category randomCategory = Category.values()[ThreadLocalRandom.current().nextInt(Category.values().length)];
+                            productService.findLowestPriceByCategory(randomCategory);
+                            readSuccessCount.incrementAndGet();
+                            break;
+                    }
+                } catch (Exception e) {
+                    // 예외 발생 시 카운트 증가 (재시도 메커니즘이 있으므로 실패가 적을 것임)
+                    exceptionCount.incrementAndGet();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+        
+        // 모든 스레드 동시 시작
+        startLatch.countDown();
+        
+        // 모든 스레드가 완료될 때까지 대기 (최대 30초)
+        boolean completed = endLatch.await(30, TimeUnit.SECONDS);
+        executorService.shutdown();
+        
+        // 검증
+        assertThat(completed).as("모든 스레드가 타임아웃 시간 내에 완료되어야 함").isTrue();
+        
+        // 모든 작업이 완료되었는지 확인 (성공 + 예외 처리 = 스레드 수)
+        int totalOperations = readSuccessCount.get() + writeSuccessCount.get() + exceptionCount.get();
+        assertThat(totalOperations).as("총 작업 수가 스레드 수와 일치해야 함").isEqualTo(threadCount);
+        
+        // 각 작업 결과 출력
+        System.out.println("Concurrent test results - Read operations: " + readSuccessCount.get() + 
+                ", Write operations: " + writeSuccessCount.get() + ", Exceptions: " + exceptionCount.get());
+        
+        // 쓰기 작업이 있었음에도 최저가 조회가 가능해야 함
+        assertThat(productService.findLowestPriceByAllCategories()).as("동시 작업 후에도 최저가 조회가 가능해야 함").isNotEmpty();
     }
 }

--- a/src/test/java/org/service/brandcody/unit/CacheTest.java
+++ b/src/test/java/org/service/brandcody/unit/CacheTest.java
@@ -1,0 +1,287 @@
+package org.service.brandcody.unit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.service.brandcody.config.CacheConfig;
+import org.service.brandcody.domain.Brand;
+import org.service.brandcody.domain.Category;
+import org.service.brandcody.domain.Product;
+import org.service.brandcody.dto.BrandTotalProjection;
+import org.service.brandcody.dto.CategoryBrandPriceDto;
+import org.service.brandcody.repository.BrandRepository;
+import org.service.brandcody.repository.ProductRepository;
+import org.service.brandcody.service.BrandService;
+import org.service.brandcody.service.ProductService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Sql(scripts = {"/schema.sql", "/fixture/data.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+public class CacheTest {
+    
+    private static final Logger logger = LoggerFactory.getLogger(CacheTest.class);
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private BrandService brandService;
+
+    @Autowired
+    private ProductService productService;
+
+    @Test
+    @DisplayName("브랜드 캐싱 테스트 - 캐시 생성 및 적중 확인")
+    void brand_cache_test() {
+        // 첫 번째 호출 - 캐시 생성
+        Brand brandFirstCall = brandService.getBrandById(1L);
+        assertThat(brandFirstCall).isNotNull();
+        
+        // 캐시에 데이터가 저장되었는지 확인
+        Object cachedBrand = Objects.requireNonNull(cacheManager.getCache(CacheConfig.BRAND_BY_ID_CACHE)).get(1L);
+        assertThat(cachedBrand).isNotNull();
+        
+        // 두 번째 호출 - 캐시 적중 확인
+        Brand brandSecondCall = brandService.getBrandById(1L);
+        
+        // 같은 객체가 반환되는지 확인
+        assertThat(brandSecondCall).isEqualTo(brandFirstCall);
+        
+        // 캐시 만료 시뮬레이션
+        Objects.requireNonNull(cacheManager.getCache(CacheConfig.BRAND_BY_ID_CACHE)).evict(1L);
+        
+        // 캐시 삭제 후 재호출 - 캐시 미스 확인
+        Brand brandThirdCall = brandService.getBrandById(1L);
+        assertThat(brandThirdCall).isNotNull();
+        
+        // 새로운 캐시 엔트리가 생성되었는지 확인
+        Object refreshedCachedBrand = Objects.requireNonNull(cacheManager.getCache(CacheConfig.BRAND_BY_ID_CACHE)).get(1L);
+        assertThat(refreshedCachedBrand).isNotNull();
+    }
+    
+    @Test
+    @DisplayName("최저가 브랜드 캐싱 테스트 - 캐시 생성 및 적중 확인")
+    void lowest_price_brand_cache_test() {
+        // 첫 번째 호출 - 캐시 생성
+        BrandTotalProjection firstCall = brandService.findBrandWithLowestTotalPrice();
+        assertThat(firstCall).isNotNull();
+        assertThat(firstCall.totalPrice()).isGreaterThan(0);
+        assertThat(firstCall.brand()).isNotNull();
+        
+        // 캐시 키 확인을 위해 모든 캐시 출력
+        logger.info("===== 캐시 키 확인 =====");
+        cacheManager.getCacheNames().forEach(cacheName -> {
+            logger.info("캐시 이름: {}", cacheName);
+            if (cacheManager.getCache(cacheName) != null) {
+                Objects.requireNonNull(cacheManager.getCache(cacheName)).getNativeCache();
+                logger.info("  캐시 내용: {}", Objects.requireNonNull(cacheManager.getCache(cacheName)).getNativeCache());
+            }
+        });
+        
+        // 캐시에 데이터가 저장되었는지 확인
+        assertThat(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BRAND_CACHE)).isNotNull();
+        
+        // 두 번째 호출 - 캐시 적중 확인
+        BrandTotalProjection secondCall = brandService.findBrandWithLowestTotalPrice();
+        assertThat(secondCall).isEqualTo(firstCall); // 동일한 객체 반환 확인
+        
+        // 가격 업데이트로 캐시 무효화 유발
+        Long lowestPriceBrandId = firstCall.brand().getId();
+        productService.updateProductByBrandAndCategory(lowestPriceBrandId, Category.TOP, 999999);
+        
+        // 캐시가 무효화되었는지 확인
+        Object invalidatedCache = Objects.requireNonNull(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BRAND_CACHE)).get("SimpleKey []");
+        assertThat(invalidatedCache).isNull();
+        
+        // 새로운 최저가 브랜드 조회
+        BrandTotalProjection thirdCall = brandService.findBrandWithLowestTotalPrice();
+        assertThat(thirdCall).isNotNull();
+        
+        // 기존 최저가 브랜드와 다른지 확인
+        assertThat(thirdCall.brand().getId()).isNotEqualTo(lowestPriceBrandId);
+    }
+    
+    @Test
+    @DisplayName("최저가 카테고리 캐싱 테스트 - 캐시 생성 및 카테고리별 키 검증")
+    void lowest_price_by_category_cache_test() {
+        // TOP 카테고리 첫 번째 호출 - 캐시 생성
+        List<CategoryBrandPriceDto> topPrices = productService.findLowestPriceByCategory(Category.TOP);
+        assertThat(topPrices).isNotEmpty();
+        assertThat(topPrices.getFirst().getCategory()).isEqualTo(Category.TOP);
+        
+        // TOP 카테고리 캐시 확인
+        Object cachedTopData = Objects.requireNonNull(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE)).get(Category.TOP.name());
+        assertThat(cachedTopData).isNotNull();
+        
+        // PANTS 카테고리 호출 - 다른 키로 캐시 생성
+        List<CategoryBrandPriceDto> pantsPrices = productService.findLowestPriceByCategory(Category.PANTS);
+        assertThat(pantsPrices).isNotEmpty();
+        assertThat(pantsPrices.getFirst().getCategory()).isEqualTo(Category.PANTS);
+        
+        // PANTS 카테고리 캐시 확인
+        Object cachedPantsData = Objects.requireNonNull(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE)).get(Category.PANTS.name());
+        assertThat(cachedPantsData).isNotNull();
+        
+        // TOP 카테고리 두 번째 호출 - 캐시 적중 확인
+        List<CategoryBrandPriceDto> topPricesSecondCall = productService.findLowestPriceByCategory(Category.TOP);
+        assertThat(topPricesSecondCall).isEqualTo(topPrices); // 동일한 객체 반환 확인
+        
+        // 특정 카테고리 캐시 무효화를 위한 가격 업데이트
+        // 브랜드 이름으로 브랜드 ID 찾기
+        String brandName = topPrices.getFirst().getBrandName();
+        Brand brand = brandService.getBrandByName(brandName);
+        productService.updateProductByBrandAndCategory(brand.getId(), Category.TOP, 99999);
+        
+        // TOP 카테고리 캐시가 무효화되었는지 확인
+        Object invalidatedTopCache = Objects.requireNonNull(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE)).get(Category.TOP.name());
+        assertThat(invalidatedTopCache).isNull();
+        
+        // PANTS 카테고리 캐시는 여전히 유효한지 확인
+        Object stillValidPantsCache = Objects.requireNonNull(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE)).get(Category.PANTS.name());
+        assertThat(stillValidPantsCache).isNotNull();
+    }
+    
+    @Test
+    @DisplayName("캐시 무효화 테스트 - 상품 가격 업데이트 후 캐시 무효화 확인")
+    void cache_eviction_after_price_update_test() {
+        // 캐시 초기화
+        cacheManager.getCacheNames().forEach(cacheName -> {
+            if (cacheManager.getCache(cacheName) != null) {
+                Objects.requireNonNull(cacheManager.getCache(cacheName)).clear();
+            }
+        });
+        
+        // 초기 데이터 캐싱
+        List<CategoryBrandPriceDto> initialPrices = productService.findLowestPriceByAllCategories();
+        assertThat(initialPrices).isNotEmpty();
+        
+        // 캐시가 생성되었는지 확인 (캐시 자체가 존재하는지만 확인)
+        assertThat(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE)).isNotNull();
+        
+        // 상품 가격 업데이트
+        Brand brand = brandRepository.findById(1L).orElseThrow();
+        productService.updateProductByBrandAndCategory(brand.getId(), Category.TOP, 99999);
+        
+        // 캐시 내용 출력
+        logger.info("===== 캐시 업데이트 후 상태 =====");
+        cacheManager.getCacheNames().forEach(cacheName -> {
+            logger.info("캐시 이름: {}", cacheName);
+            if (cacheManager.getCache(cacheName) != null) {
+                Objects.requireNonNull(cacheManager.getCache(cacheName)).getNativeCache();
+                logger.info("  캐시 내용: {}", Objects.requireNonNull(cacheManager.getCache(cacheName)).getNativeCache());
+            }
+        });
+        
+        // 새로운 데이터 요청 시 캐시가 다시 생성되는지 확인
+        List<CategoryBrandPriceDto> updatedPrices = productService.findLowestPriceByAllCategories();
+        
+        // TOP 카테고리에 대한 최저가 브랜드가 변경되었는지 확인
+        CategoryBrandPriceDto topCategoryPrice = updatedPrices.stream()
+                .filter(dto -> dto.getCategory() == Category.TOP)
+                .findFirst()
+                .orElseThrow();
+                
+        // TestA가 더이상 TOP 카테고리의 최저가 브랜드가 아님
+        if (brand.getName().equals("TestA")) {
+            assertThat(topCategoryPrice.getBrandName()).isNotEqualTo("TestA");
+        }
+    }
+    
+    @Test
+    @DisplayName("캐시 무효화 테스트 - 다양한 작업 후 캐시 상태 확인")
+    void cache_eviction_test() {
+        // 캐시 초기화
+        cacheManager.getCacheNames().forEach(cacheName -> {
+            if (cacheManager.getCache(cacheName) != null) {
+                Objects.requireNonNull(cacheManager.getCache(cacheName)).clear();
+            }
+        });
+        
+        // 1. 초기 데이터 로드 및 캐시 생성
+        Brand brand = brandService.getBrandById(1L);
+        
+        // 캐시 상태 확인 (단순히 존재 여부만 확인)
+        assertThat(cacheManager.getCache(CacheConfig.BRAND_BY_ID_CACHE)).isNotNull();
+        assertThat(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE)).isNotNull();
+        assertThat(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BRAND_CACHE)).isNotNull();
+        
+        // 2. 브랜드 업데이트 후 브랜드 캐시 무효화 확인
+        brandService.updateBrand(1L, "UpdatedBrandName");
+        assertThat(Objects.requireNonNull(cacheManager.getCache(CacheConfig.BRAND_BY_ID_CACHE)).get(1L)).isNull();
+        
+        // 3. 상품 가격 업데이트 후 관련 캐시 무효화 확인
+        Category targetCategory = Category.TOP;
+        Long brandIdToUpdate = brand.getId();
+        
+        productService.updateProductByBrandAndCategory(brandIdToUpdate, targetCategory, 99999);
+        
+        // 카테고리별 최저가 캐시가 무효화되었는지 확인
+        assertThat(Objects.requireNonNull(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE)).get(targetCategory.name())).isNull();
+        
+        // 전체 카테고리 최저가 캐시가 무효화되었는지 확인
+        assertThat(Objects.requireNonNull(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE)).get("SimpleKey []")).isNull();
+        
+        // 최저가 브랜드 캐시가 무효화되었는지 확인
+        assertThat(Objects.requireNonNull(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BRAND_CACHE)).get("SimpleKey []")).isNull();
+    }
+    
+    @Test
+    @DisplayName("캐시 성능 향상 테스트")
+    void cache_performance_test() {
+        // 캐시 지우기 (테스트 격리)
+        Objects.requireNonNull(cacheManager.getCache(CacheConfig.BRAND_BY_ID_CACHE)).clear();
+        
+        // 첫 번째 호출 시간 측정 (캐시 미스)
+        long startTime1 = System.nanoTime();
+        Brand brand1 = brandService.getBrandById(1L);
+        long endTime1 = System.nanoTime();
+        long duration1 = endTime1 - startTime1;
+        
+        // 두 번째 호출 시간 측정 (캐시 히트)
+        long startTime2 = System.nanoTime();
+        Brand brand2 = brandService.getBrandById(1L);
+        long endTime2 = System.nanoTime();
+        long duration2 = endTime2 - startTime2;
+        
+        // 캐시 적중 시 성능이 향상되었는지 확인
+        assertThat(duration2).isLessThan(duration1);
+        logger.info("캐시 미스 시간(ns): {}", duration1);
+        logger.info("캐시 히트 시간(ns): {}", duration2);
+        logger.info("성능 향상률: {}%", ((duration1 - duration2) * 100.0 / duration1));
+    }
+    
+    @Test
+    @DisplayName("캐시 키 전략 테스트 - 다양한 파라미터 조합")
+    void cache_key_strategy_test() {
+        // 다양한 파라미터 조합으로 캐시 키 생성 테스트
+        productService.findLowestPriceByCategory(Category.TOP);
+        productService.findLowestPriceByCategory(Category.PANTS);
+        
+        // 각 카테고리별로 별도의 캐시 엔트리가 생성되었는지 확인
+        assertThat(Objects.requireNonNull(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE)).get(Category.TOP.name())).isNotNull();
+        assertThat(Objects.requireNonNull(cacheManager.getCache(CacheConfig.LOWEST_PRICE_BY_CATEGORY_CACHE)).get(Category.PANTS.name())).isNotNull();
+        
+        // 브랜드와 카테고리 조합 캐시 테스트
+        Long brandId = 1L;
+        productService.getProductByBrandAndCategory(brandId, Category.TOP);
+        productService.getProductByBrandAndCategory(brandId, Category.PANTS);
+        
+        // 각 조합별로 별도의 캐시 엔트리가 생성되었는지 확인
+        assertThat(Objects.requireNonNull(cacheManager.getCache(CacheConfig.PRODUCT_BY_BRAND_CATEGORY_CACHE)).get(brandId + "-TOP")).isNotNull();
+        assertThat(Objects.requireNonNull(cacheManager.getCache(CacheConfig.PRODUCT_BY_BRAND_CATEGORY_CACHE)).get(brandId + "-PANTS")).isNotNull();
+    }
+}


### PR DESCRIPTION
### 성능 향상을 위한 Spring Cache 기반 캐싱 전략 도입
- 상품 카테고리별 최저가 조회 성능 개선
  - 복잡한 집계 쿼리(최저가 브랜드) 결과 캐싱
- 브랜드/상품 조회 연산에 캐시 적용 (@Cacheable)
- 데이터 변경 시 캐시 무효화 (@CacheEvict)
  - 키 전략 최적화로 세분화된 캐시 무효화
- 다중 캐시 처리를 위한 조합 어노테이션 사용 (@Caching)
### 관련 테스트 추가 
- 캐시 생성 및 적중 테스트
- 카테고리별 캐시 키 전략 검증
- 캐시 무효화 확인 테스트
- 성능 향상 측정 테스트