### PR TITLE
[PR-5] Add Concurrency handling using application level lock

### DIFF
--- a/src/main/java/org/service/brandcody/BrandCodyApplication.java
+++ b/src/main/java/org/service/brandcody/BrandCodyApplication.java
@@ -2,8 +2,10 @@ package org.service.brandcody;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
+@EnableRetry
 public class BrandCodyApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/service/brandcody/controller/ProductController.java
+++ b/src/main/java/org/service/brandcody/controller/ProductController.java
@@ -50,6 +50,9 @@ public class ProductController {
     public ResponseEntity<ProductResponse> createProduct(
             @PathVariable Long brandId,
             @Valid @RequestBody ProductRequest request) {
+        if (request.getCategory() == null) {
+            throw new IllegalArgumentException("Category is required for creating a new product");
+        }
         Product product = productService.createProduct(brandId, request.getCategory(), request.getPrice());
         return new ResponseEntity<>(ProductResponse.from(product), HttpStatus.CREATED);
     }

--- a/src/main/java/org/service/brandcody/domain/Brand.java
+++ b/src/main/java/org/service/brandcody/domain/Brand.java
@@ -22,6 +22,9 @@ public class Brand {
 
     @Column(nullable = false, unique = true)
     private String name;
+    
+    @Version
+    private Long version;
 
     @OneToMany(mappedBy = "brand", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Product> products = new ArrayList<>();

--- a/src/main/java/org/service/brandcody/domain/Product.java
+++ b/src/main/java/org/service/brandcody/domain/Product.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 
 @Entity
 @Table(name = "products", indexes = {
-        @Index(name = "idx_product_brand_category", columnList = "brand_id, category"),
+        @Index(name = "idx_product_brand_category", columnList = "brand_id, category", unique = true),
         @Index(name = "idx_product_category_price", columnList = "category, price")
 })
 
@@ -29,6 +29,9 @@ public class Product {
 
     @Column(nullable = false)
     private Integer price;
+    
+    @Version
+    private Long version;
 
     public Product(Category category, Integer price) {
         this.category = category;

--- a/src/main/java/org/service/brandcody/dto/request/ProductRequest.java
+++ b/src/main/java/org/service/brandcody/dto/request/ProductRequest.java
@@ -9,7 +9,6 @@ import org.service.brandcody.domain.Category;
 @Getter
 @NoArgsConstructor
 public class ProductRequest {
-    @NotNull(message = "Category cannot be null")
     private Category category;
     
     @NotNull(message = "Price cannot be null")

--- a/src/main/java/org/service/brandcody/repository/ProductRepository.java
+++ b/src/main/java/org/service/brandcody/repository/ProductRepository.java
@@ -13,6 +13,9 @@ import java.util.Optional;
 public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findByBrandIdOrderByCategory(Long brandId);
     Optional<Product> findByBrandIdAndCategory(Long brandId, Category category);
+    
+    // 동시성 테스트를 위한 카운트 메서드
+    long countByBrandIdAndCategory(Long brandId, Category category);
 
     // 모든 카테고리에 대해 최저가격 브랜드와 가격 조회 쿼리
     @Query("SELECT new org.service.brandcody.dto.CategoryBrandPriceDto(p.category, b.name, p.price) FROM Product p JOIN p.brand b " +

--- a/src/main/java/org/service/brandcody/service/BrandService.java
+++ b/src/main/java/org/service/brandcody/service/BrandService.java
@@ -1,16 +1,22 @@
 package org.service.brandcody.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.service.brandcody.domain.Brand;
 import org.service.brandcody.dto.BrandTotalProjection;
 import org.service.brandcody.repository.BrandRepository;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -33,31 +39,53 @@ public class BrandService {
 
     @Transactional
     public Brand createBrand(String name) {
-        if (brandRepository.findByName(name).isPresent()) {
+        try {
+            Brand brand = new Brand();
+            brand.setName(name);
+            return brandRepository.save(brand);
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Attempt to create duplicate brand with name: {}", name);
             throw new IllegalArgumentException("Brand with name '" + name + "' already exists");
         }
-        
-        Brand brand = new Brand();
-        brand.setName(name);
-        return brandRepository.save(brand);
     }
 
+    @Retryable(
+        value = {ObjectOptimisticLockingFailureException.class},
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 500)
+    )
     @Transactional
     public Brand updateBrand(Long id, String name) {
+        log.debug("Attempting to update brand with id: {} to name: {}", id, name);
         Brand brand = getBrandById(id);
         
-        if (!brand.getName().equals(name) && brandRepository.findByName(name).isPresent()) {
+        try {
+            brand.setName(name);
+            return brandRepository.save(brand);
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Attempt to update brand to a duplicate name: {}", name);
             throw new IllegalArgumentException("Brand with name '" + name + "' already exists");
+        } catch (ObjectOptimisticLockingFailureException e) {
+            log.warn("Optimistic locking failure when updating brand id: {}. Retry attempt will follow.", id);
+            throw e;
         }
-        
-        brand.setName(name);
-        return brandRepository.save(brand);
     }
 
+    @Retryable(
+        value = {ObjectOptimisticLockingFailureException.class},
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 500)
+    )
     @Transactional
     public void deleteBrand(Long id) {
+        log.debug("Attempting to delete brand with id: {}", id);
         Brand brand = getBrandById(id);
-        brandRepository.delete(brand);
+        try {
+            brandRepository.delete(brand);
+        } catch (ObjectOptimisticLockingFailureException e) {
+            log.warn("Optimistic locking failure when deleting brand id: {}. Retry attempt will follow.", id);
+            throw e;
+        }
     }
 
     public BrandTotalProjection findBrandWithLowestTotalPrice() {
@@ -67,7 +95,7 @@ public class BrandService {
             throw new NoSuchElementException("모든 카테고리의 상품을 보유한 브랜드를 찾을 수 없습니다. 각 브랜드는 모든 카테고리(상의, 아우터, 바지, 스니커즈, 가방, 모자, 양말, 액세서리)의 상품을 가지고 있어야 합니다.");
         }
         
-        return result.get(0);
+        return result.getFirst();
     }
 
     public List<BrandTotalProjection> findAllBrandsWithTotalPrice() {

--- a/src/main/java/org/service/brandcody/service/ProductService.java
+++ b/src/main/java/org/service/brandcody/service/ProductService.java
@@ -1,12 +1,17 @@
 package org.service.brandcody.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.service.brandcody.domain.Brand;
 import org.service.brandcody.domain.Category;
 import org.service.brandcody.domain.Product;
 import org.service.brandcody.dto.CategoryBrandPriceDto;
 import org.service.brandcody.repository.BrandRepository;
 import org.service.brandcody.repository.ProductRepository;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +19,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -43,39 +49,73 @@ public class ProductService {
         Brand brand = brandRepository.findById(brandId)
                 .orElseThrow(() -> new NoSuchElementException("Brand not found with id: " + brandId));
 
-        Optional<Product> existingProduct = productRepository.findByBrandIdAndCategory(brandId, category);
-        if (existingProduct.isPresent()) {
+        try {
+            Product product = new Product(category, price);
+            brand.addProduct(product);
+            return productRepository.save(product);
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Concurrent product creation detected for brand {} and category {}", brandId, category);
             throw new IllegalArgumentException("Product already exists for this brand and category");
         }
-
-        Product product = new Product(category, price);
-        brand.addProduct(product);
-        return productRepository.save(product);
     }
 
+    @Retryable(
+        value = {ObjectOptimisticLockingFailureException.class},
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 500)
+    )
     @Transactional
     public Product updateProduct(Long id, Integer price) {
+        log.debug("Attempting to update product with id: {} to price: {}", id, price);
         Product product = getProductById(id);
         product.updatePrice(price);
-        return productRepository.save(product);
+        try {
+            return productRepository.save(product);
+        } catch (ObjectOptimisticLockingFailureException e) {
+            log.warn("Optimistic locking failure when updating product id: {}. Retry attempt will follow.", id);
+            throw e;
+        }
     }
 
+    @Retryable(
+        value = {ObjectOptimisticLockingFailureException.class},
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 500)
+    )
     @Transactional
     public Product updateProductByBrandAndCategory(Long brandId, Category category, Integer price) {
+        log.debug("Attempting to update product for brand id: {} and category: {} to price: {}", brandId, category, price);
         Product product = productRepository.findByBrandIdAndCategory(brandId, category)
                 .orElseThrow(() -> new NoSuchElementException(
                         "Product not found for brand id: " + brandId + " and category: " + category));
         
         product.updatePrice(price);
-        return productRepository.save(product);
+        try {
+            return productRepository.save(product);
+        } catch (ObjectOptimisticLockingFailureException e) {
+            log.warn("Optimistic locking failure when updating product for brand id: {} and category: {}. Retry attempt will follow.", 
+                     brandId, category);
+            throw e;
+        }
     }
 
+    @Retryable(
+        value = {ObjectOptimisticLockingFailureException.class},
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 500)
+    )
     @Transactional
     public void deleteProduct(Long id) {
+        log.debug("Attempting to delete product with id: {}", id);
         Product product = getProductById(id);
         Brand brand = product.getBrand();
         brand.removeProduct(product);
-        productRepository.delete(product);
+        try {
+            productRepository.delete(product);
+        } catch (ObjectOptimisticLockingFailureException e) {
+            log.warn("Optimistic locking failure when deleting product id: {}. Retry attempt will follow.", id);
+            throw e;
+        }
     }
 
     public List<CategoryBrandPriceDto> findLowestPriceByAllCategories() {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,100 +1,100 @@
 -- 브랜드 데이터 추가
-INSERT INTO brands (id, name) VALUES (1, 'A');
-INSERT INTO brands (id, name) VALUES (2, 'B');
-INSERT INTO brands (id, name) VALUES (3, 'C');
-INSERT INTO brands (id, name) VALUES (4, 'D');
-INSERT INTO brands (id, name) VALUES (5, 'E');
-INSERT INTO brands (id, name) VALUES (6, 'F');
-INSERT INTO brands (id, name) VALUES (7, 'G');
-INSERT INTO brands (id, name) VALUES (8, 'H');
-INSERT INTO brands (id, name) VALUES (9, 'I');
+INSERT INTO brands (id, name, version) VALUES (1, 'A', 0);
+INSERT INTO brands (id, name, version) VALUES (2, 'B', 0);
+INSERT INTO brands (id, name, version) VALUES (3, 'C', 0);
+INSERT INTO brands (id, name, version) VALUES (4, 'D', 0);
+INSERT INTO brands (id, name, version) VALUES (5, 'E', 0);
+INSERT INTO brands (id, name, version) VALUES (6, 'F', 0);
+INSERT INTO brands (id, name, version) VALUES (7, 'G', 0);
+INSERT INTO brands (id, name, version) VALUES (8, 'H', 0);
+INSERT INTO brands (id, name, version) VALUES (9, 'I', 0);
 
 -- 브랜드 A 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (1, 1, 'TOP', 11200);
-INSERT INTO products (id, brand_id, category, price) VALUES (2, 1, 'OUTER', 5500);
-INSERT INTO products (id, brand_id, category, price) VALUES (3, 1, 'PANTS', 4200);
-INSERT INTO products (id, brand_id, category, price) VALUES (4, 1, 'SNEAKERS', 9000);
-INSERT INTO products (id, brand_id, category, price) VALUES (5, 1, 'BAG', 2000);
-INSERT INTO products (id, brand_id, category, price) VALUES (6, 1, 'HAT', 1700);
-INSERT INTO products (id, brand_id, category, price) VALUES (7, 1, 'SOCKS', 1800);
-INSERT INTO products (id, brand_id, category, price) VALUES (8, 1, 'ACCESSORY', 2300);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (1, 1, 'TOP', 11200, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (2, 1, 'OUTER', 5500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (3, 1, 'PANTS', 4200, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (4, 1, 'SNEAKERS', 9000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (5, 1, 'BAG', 2000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (6, 1, 'HAT', 1700, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (7, 1, 'SOCKS', 1800, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (8, 1, 'ACCESSORY', 2300, 0);
 
 -- 브랜드 B 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (9, 2, 'TOP', 10500);
-INSERT INTO products (id, brand_id, category, price) VALUES (10, 2, 'OUTER', 5900);
-INSERT INTO products (id, brand_id, category, price) VALUES (11, 2, 'PANTS', 3800);
-INSERT INTO products (id, brand_id, category, price) VALUES (12, 2, 'SNEAKERS', 9100);
-INSERT INTO products (id, brand_id, category, price) VALUES (13, 2, 'BAG', 2100);
-INSERT INTO products (id, brand_id, category, price) VALUES (14, 2, 'HAT', 2000);
-INSERT INTO products (id, brand_id, category, price) VALUES (15, 2, 'SOCKS', 2000);
-INSERT INTO products (id, brand_id, category, price) VALUES (16, 2, 'ACCESSORY', 2200);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (9, 2, 'TOP', 10500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (10, 2, 'OUTER', 5900, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (11, 2, 'PANTS', 3800, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (12, 2, 'SNEAKERS', 9100, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (13, 2, 'BAG', 2100, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (14, 2, 'HAT', 2000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (15, 2, 'SOCKS', 2000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (16, 2, 'ACCESSORY', 2200, 0);
 
 -- 브랜드 C 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (17, 3, 'TOP', 10000);
-INSERT INTO products (id, brand_id, category, price) VALUES (18, 3, 'OUTER', 6200);
-INSERT INTO products (id, brand_id, category, price) VALUES (19, 3, 'PANTS', 3300);
-INSERT INTO products (id, brand_id, category, price) VALUES (20, 3, 'SNEAKERS', 9200);
-INSERT INTO products (id, brand_id, category, price) VALUES (21, 3, 'BAG', 2200);
-INSERT INTO products (id, brand_id, category, price) VALUES (22, 3, 'HAT', 1900);
-INSERT INTO products (id, brand_id, category, price) VALUES (23, 3, 'SOCKS', 2200);
-INSERT INTO products (id, brand_id, category, price) VALUES (24, 3, 'ACCESSORY', 2100);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (17, 3, 'TOP', 10000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (18, 3, 'OUTER', 6200, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (19, 3, 'PANTS', 3300, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (20, 3, 'SNEAKERS', 9200, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (21, 3, 'BAG', 2200, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (22, 3, 'HAT', 1900, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (23, 3, 'SOCKS', 2200, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (24, 3, 'ACCESSORY', 2100, 0);
 
 -- 브랜드 D 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (25, 4, 'TOP', 10100);
-INSERT INTO products (id, brand_id, category, price) VALUES (26, 4, 'OUTER', 5100);
-INSERT INTO products (id, brand_id, category, price) VALUES (27, 4, 'PANTS', 3000);
-INSERT INTO products (id, brand_id, category, price) VALUES (28, 4, 'SNEAKERS', 9500);
-INSERT INTO products (id, brand_id, category, price) VALUES (29, 4, 'BAG', 2500);
-INSERT INTO products (id, brand_id, category, price) VALUES (30, 4, 'HAT', 1500);
-INSERT INTO products (id, brand_id, category, price) VALUES (31, 4, 'SOCKS', 2400);
-INSERT INTO products (id, brand_id, category, price) VALUES (32, 4, 'ACCESSORY', 1900);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (25, 4, 'TOP', 10100, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (26, 4, 'OUTER', 5100, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (27, 4, 'PANTS', 3000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (28, 4, 'SNEAKERS', 9500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (29, 4, 'BAG', 2500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (30, 4, 'HAT', 1500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (31, 4, 'SOCKS', 2400, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (32, 4, 'ACCESSORY', 1900, 0);
 
 -- 브랜드 E 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (33, 5, 'TOP', 10700);
-INSERT INTO products (id, brand_id, category, price) VALUES (34, 5, 'OUTER', 5000);
-INSERT INTO products (id, brand_id, category, price) VALUES (35, 5, 'PANTS', 3800);
-INSERT INTO products (id, brand_id, category, price) VALUES (36, 5, 'SNEAKERS', 9900);
-INSERT INTO products (id, brand_id, category, price) VALUES (37, 5, 'BAG', 2300);
-INSERT INTO products (id, brand_id, category, price) VALUES (38, 5, 'HAT', 1800);
-INSERT INTO products (id, brand_id, category, price) VALUES (39, 5, 'SOCKS', 2100);
-INSERT INTO products (id, brand_id, category, price) VALUES (40, 5, 'ACCESSORY', 2000);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (33, 5, 'TOP', 10700, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (34, 5, 'OUTER', 5000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (35, 5, 'PANTS', 3800, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (36, 5, 'SNEAKERS', 9900, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (37, 5, 'BAG', 2300, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (38, 5, 'HAT', 1800, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (39, 5, 'SOCKS', 2100, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (40, 5, 'ACCESSORY', 2000, 0);
 
 -- 브랜드 F 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (41, 6, 'TOP', 11200);
-INSERT INTO products (id, brand_id, category, price) VALUES (42, 6, 'OUTER', 7200);
-INSERT INTO products (id, brand_id, category, price) VALUES (43, 6, 'PANTS', 4000);
-INSERT INTO products (id, brand_id, category, price) VALUES (44, 6, 'SNEAKERS', 9300);
-INSERT INTO products (id, brand_id, category, price) VALUES (45, 6, 'BAG', 2100);
-INSERT INTO products (id, brand_id, category, price) VALUES (46, 6, 'HAT', 1600);
-INSERT INTO products (id, brand_id, category, price) VALUES (47, 6, 'SOCKS', 1700);
-INSERT INTO products (id, brand_id, category, price) VALUES (48, 6, 'ACCESSORY', 2000);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (41, 6, 'TOP', 11200, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (42, 6, 'OUTER', 7200, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (43, 6, 'PANTS', 4000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (44, 6, 'SNEAKERS', 9300, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (45, 6, 'BAG', 2100, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (46, 6, 'HAT', 1600, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (47, 6, 'SOCKS', 1700, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (48, 6, 'ACCESSORY', 2000, 0);
 
 -- 브랜드 G 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (49, 7, 'TOP', 10500);
-INSERT INTO products (id, brand_id, category, price) VALUES (50, 7, 'OUTER', 5800);
-INSERT INTO products (id, brand_id, category, price) VALUES (51, 7, 'PANTS', 3900);
-INSERT INTO products (id, brand_id, category, price) VALUES (52, 7, 'SNEAKERS', 8900);
-INSERT INTO products (id, brand_id, category, price) VALUES (53, 7, 'BAG', 2000);
-INSERT INTO products (id, brand_id, category, price) VALUES (54, 7, 'HAT', 1700);
-INSERT INTO products (id, brand_id, category, price) VALUES (55, 7, 'SOCKS', 1600);
-INSERT INTO products (id, brand_id, category, price) VALUES (56, 7, 'ACCESSORY', 1700);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (49, 7, 'TOP', 10500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (50, 7, 'OUTER', 5800, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (51, 7, 'PANTS', 3900, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (52, 7, 'SNEAKERS', 8900, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (53, 7, 'BAG', 2000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (54, 7, 'HAT', 1700, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (55, 7, 'SOCKS', 1600, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (56, 7, 'ACCESSORY', 1700, 0);
 
 -- 브랜드 H 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (57, 8, 'TOP', 10800);
-INSERT INTO products (id, brand_id, category, price) VALUES (58, 8, 'OUTER', 6300);
-INSERT INTO products (id, brand_id, category, price) VALUES (59, 8, 'PANTS', 4100);
-INSERT INTO products (id, brand_id, category, price) VALUES (60, 8, 'SNEAKERS', 9700);
-INSERT INTO products (id, brand_id, category, price) VALUES (61, 8, 'BAG', 1700);
-INSERT INTO products (id, brand_id, category, price) VALUES (62, 8, 'HAT', 1600);
-INSERT INTO products (id, brand_id, category, price) VALUES (63, 8, 'SOCKS', 1500);
-INSERT INTO products (id, brand_id, category, price) VALUES (64, 8, 'ACCESSORY', 1900);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (57, 8, 'TOP', 10800, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (58, 8, 'OUTER', 6300, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (59, 8, 'PANTS', 4100, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (60, 8, 'SNEAKERS', 9700, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (61, 8, 'BAG', 1700, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (62, 8, 'HAT', 1600, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (63, 8, 'SOCKS', 1500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (64, 8, 'ACCESSORY', 1900, 0);
 
 -- 브랜드 I 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (65, 9, 'TOP', 11400);
-INSERT INTO products (id, brand_id, category, price) VALUES (66, 9, 'OUTER', 6500);
-INSERT INTO products (id, brand_id, category, price) VALUES (67, 9, 'PANTS', 3600);
-INSERT INTO products (id, brand_id, category, price) VALUES (68, 9, 'SNEAKERS', 9800);
-INSERT INTO products (id, brand_id, category, price) VALUES (69, 9, 'BAG', 1900);
-INSERT INTO products (id, brand_id, category, price) VALUES (70, 9, 'HAT', 1700);
-INSERT INTO products (id, brand_id, category, price) VALUES (71, 9, 'SOCKS', 2000);
-INSERT INTO products (id, brand_id, category, price) VALUES (72, 9, 'ACCESSORY', 2100);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (65, 9, 'TOP', 11400, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (66, 9, 'OUTER', 6500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (67, 9, 'PANTS', 3600, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (68, 9, 'SNEAKERS', 9800, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (69, 9, 'BAG', 1900, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (70, 9, 'HAT', 1700, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (71, 9, 'SOCKS', 2000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (72, 9, 'ACCESSORY', 2100, 0);

--- a/src/test/java/org/service/brandcody/integration/ConcurrencyTest.java
+++ b/src/test/java/org/service/brandcody/integration/ConcurrencyTest.java
@@ -1,0 +1,242 @@
+package org.service.brandcody.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.service.brandcody.domain.Brand;
+import org.service.brandcody.domain.Category;
+import org.service.brandcody.domain.Product;
+import org.service.brandcody.repository.BrandRepository;
+import org.service.brandcody.repository.ProductRepository;
+import org.service.brandcody.service.ProductService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ConcurrencyTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+    
+    @Autowired
+    private ProductService productService;
+
+    private Brand testBrand;
+    private Long brandId;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 전에 기존 데이터 삭제
+        productRepository.deleteAll();
+        brandRepository.deleteAll();
+
+        // 테스트 브랜드 생성
+        testBrand = new Brand();
+        testBrand.setName("ConcurrencyTestBrand");
+        testBrand = brandRepository.save(testBrand);
+        brandId = testBrand.getId();
+    }
+
+    @Test
+    @DisplayName("동일 브랜드-카테고리로 상품 동시 생성 시 하나만 성공해야 함")
+    void concurrentProductCreationTest() throws Exception {
+        // 동일한 카테고리와 브랜드로 동시에 두 개의 상품을 생성
+        String productRequestJson = "{\"category\":\"TOP\",\"price\":10000}";
+        
+        // 성공/실패 카운터
+        final AtomicInteger successCount = new AtomicInteger(0);
+        final AtomicInteger failureCount = new AtomicInteger(0);
+        
+        // 스레드 동기화를 위한 래치
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(2);
+        
+        // 스레드 풀 생성
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        
+        // 첫 번째 스레드: 상품 생성 요청
+        executorService.submit(() -> {
+            try {
+                startLatch.await(); // 메인 스레드가 시작 신호를 줄 때까지 대기
+                MvcResult result = mockMvc.perform(post("/api/products/brand/{brandId}", brandId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(productRequestJson))
+                        .andReturn();
+                
+                int status = result.getResponse().getStatus();
+                if (status == 201) {
+                    successCount.incrementAndGet();
+                } else {
+                    failureCount.incrementAndGet();
+                }
+            } catch (Exception e) {
+                failureCount.incrementAndGet();
+            } finally {
+                endLatch.countDown();
+            }
+        });
+        
+        // 두 번째 스레드: 동일한 상품 생성 요청
+        executorService.submit(() -> {
+            try {
+                startLatch.await(); // 메인 스레드가 시작 신호를 줄 때까지 대기
+                MvcResult result = mockMvc.perform(post("/api/products/brand/{brandId}", brandId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(productRequestJson))
+                        .andReturn();
+                
+                int status = result.getResponse().getStatus();
+                if (status == 201) {
+                    successCount.incrementAndGet();
+                } else {
+                    failureCount.incrementAndGet();
+                }
+            } catch (Exception e) {
+                failureCount.incrementAndGet();
+            } finally {
+                endLatch.countDown();
+            }
+        });
+        
+        // 두 스레드를 동시에 시작
+        startLatch.countDown();
+        
+        // 모든 스레드가 완료될 때까지 대기 (최대 10초)
+        boolean completed = endLatch.await(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        // 1. 모든 스레드가 제한 시간 내에 종료되었는지 확인
+        assertThat(completed).as("All threads should complete within the timeout").isTrue();
+        
+        // 2. 데이터베이스 상태 검증: 해당 브랜드-카테고리 조합의 상품이 정확히 하나만 존재해야 함
+        long productCount = productRepository.countByBrandIdAndCategory(brandId, Category.TOP);
+        assertThat(productCount).as("Only one product should exist for the brand-category combination").isEqualTo(1);
+        
+        // 3. 검증: 요청이 정확히 2개 처리됨 (성공 1개 + 실패 1개)
+        int total = successCount.get() + failureCount.get();
+        assertThat(total).as("Total requests processed should be 2").isEqualTo(2);
+        
+        // 4. 성공 1개, 실패 1개 검증
+        assertThat(successCount.get()).as("Successfully created products should be 1").isEqualTo(1);
+        assertThat(failureCount.get()).as("Failed creation attempts should be 1").isEqualTo(1);
+    }
+    
+    @Test
+    @DisplayName("낙관적 락을 통한 동시 수정 충돌 테스트 및 재시도 확인")
+    void optimisticLockingAndRetryTest() throws Exception {
+        // 상품 생성
+        Product product = productService.createProduct(brandId, Category.TOP, 10000);
+        Long productId = product.getId();
+        
+        // 업데이트 요청 JSON
+        String updateRequest1 = "{\"price\":15000}";
+        String updateRequest2 = "{\"price\":20000}";
+        
+        // 스레드 동기화를 위한 래치
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(2);
+        
+        // 성공/실패 카운터
+        final AtomicInteger successCount = new AtomicInteger(0);
+        final AtomicInteger failureCount = new AtomicInteger(0);
+
+        // 스레드 풀 생성
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        
+        // 첫 번째 스레드: 가격 업데이트 1
+        Future<?> future1 = executorService.submit(() -> {
+            try {
+                startLatch.await(); // 메인 스레드가 시작 신호를 줄 때까지 대기
+                Thread.sleep(10);
+                
+                MvcResult result = mockMvc.perform(put("/api/products/{productId}", productId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateRequest1))
+                        .andReturn();
+                
+                int status = result.getResponse().getStatus();
+                if (status == 200) {
+                    successCount.incrementAndGet();
+                } else {
+                    failureCount.incrementAndGet();
+                }
+            } catch (Exception e) {
+                failureCount.incrementAndGet();
+            } finally {
+                endLatch.countDown();
+            }
+        });
+        
+        // 두 번째 스레드: 가격 업데이트 2
+        Future<?> future2 = executorService.submit(() -> {
+            try {
+                startLatch.await(); // 메인 스레드가 시작 신호를 줄 때까지 대기
+                
+                MvcResult result = mockMvc.perform(put("/api/products/{productId}", productId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateRequest2))
+                        .andReturn();
+                
+                int status = result.getResponse().getStatus();
+                if (status == 200) {
+                    successCount.incrementAndGet();
+                } else {
+                    failureCount.incrementAndGet();
+                }
+            } catch (Exception e) {
+                failureCount.incrementAndGet();
+            } finally {
+                endLatch.countDown();
+            }
+        });
+        
+        // 두 스레드를 동시에 시작
+        startLatch.countDown();
+        
+        // 모든 스레드가 완료될 때까지 대기 (최대 10초)
+        boolean completed = endLatch.await(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+        
+        // 두 작업이 모두 완료될 때까지 대기
+        future1.get(5, TimeUnit.SECONDS);
+        future2.get(5, TimeUnit.SECONDS);
+        
+        // 검증
+        // 1. 모든 스레드가 제한 시간 내에 종료되었는지 확인
+        assertThat(completed).as("All threads should complete within the timeout").isTrue();
+        
+        // 2. 두 요청 모두 성공했는지 확인 (재시도를 통해)
+        assertThat(successCount.get()).as("Both update operations should succeed due to retry").isEqualTo(2);
+        assertThat(failureCount.get()).as("No failures should occur with retry").isEqualTo(0);
+        
+        // 3. 최신 상품 정보 확인
+        Product updatedProduct = productRepository.findById(productId).orElseThrow();
+        // 둘 중 하나의 가격이 적용되어 있어야 함
+        assertThat(updatedProduct.getPrice()).as("Product price should be updated to one of the values")
+                .isIn(15000, 20000);
+    }
+}

--- a/src/test/java/org/service/brandcody/integration/PriceApiTest.java
+++ b/src/test/java/org/service/brandcody/integration/PriceApiTest.java
@@ -28,6 +28,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
+@ActiveProfiles("test")
+@Sql(scripts = {"/schema.sql", "/fixture/data.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 public class PriceApiTest {
 
     @Autowired

--- a/src/test/java/org/service/brandcody/unit/BrandServiceTest.java
+++ b/src/test/java/org/service/brandcody/unit/BrandServiceTest.java
@@ -113,7 +113,6 @@ public class BrandServiceTest {
         newBrand.setId(2L);
         newBrand.setName(brandName);
 
-        when(brandRepository.findByName(brandName)).thenReturn(Optional.empty());
         when(brandRepository.save(any(Brand.class))).thenReturn(newBrand);
 
         // When
@@ -123,7 +122,6 @@ public class BrandServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(2L);
         assertThat(result.getName()).isEqualTo(brandName);
-        verify(brandRepository).findByName(brandName);
         verify(brandRepository).save(any(Brand.class));
     }
 
@@ -132,14 +130,13 @@ public class BrandServiceTest {
     void createBrand_DuplicateName_ThrowsException() {
         // Given
         String brandName = "TestBrand";
-        when(brandRepository.findByName(brandName)).thenReturn(Optional.of(testBrand));
+        when(brandRepository.save(any(Brand.class))).thenThrow(new org.springframework.dao.DataIntegrityViolationException("Duplicate entry"));
 
         // When & Then
         assertThatThrownBy(() -> brandService.createBrand(brandName))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Brand with name 'TestBrand' already exists");
-        verify(brandRepository).findByName(brandName);
-        verify(brandRepository, never()).save(any(Brand.class));
+        verify(brandRepository).save(any(Brand.class));
     }
 
     @Test
@@ -154,7 +151,6 @@ public class BrandServiceTest {
         updatedBrand.setName(newName);
 
         when(brandRepository.findById(brandId)).thenReturn(Optional.of(testBrand));
-        when(brandRepository.findByName(newName)).thenReturn(Optional.empty());
         when(brandRepository.save(any(Brand.class))).thenReturn(updatedBrand);
 
         // When
@@ -165,7 +161,6 @@ public class BrandServiceTest {
         assertThat(result.getId()).isEqualTo(brandId);
         assertThat(result.getName()).isEqualTo(newName);
         verify(brandRepository).findById(brandId);
-        verify(brandRepository).findByName(newName);
         verify(brandRepository).save(any(Brand.class));
     }
 
@@ -175,21 +170,16 @@ public class BrandServiceTest {
         // Given
         Long brandId = 1L;
         String newName = "ExistingBrand";
-        
-        Brand existingBrand = new Brand();
-        existingBrand.setId(2L);
-        existingBrand.setName(newName);
 
         when(brandRepository.findById(brandId)).thenReturn(Optional.of(testBrand));
-        when(brandRepository.findByName(newName)).thenReturn(Optional.of(existingBrand));
+        when(brandRepository.save(any(Brand.class))).thenThrow(new org.springframework.dao.DataIntegrityViolationException("Duplicate entry"));
 
         // When & Then
         assertThatThrownBy(() -> brandService.updateBrand(brandId, newName))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Brand with name 'ExistingBrand' already exists");
         verify(brandRepository).findById(brandId);
-        verify(brandRepository).findByName(newName);
-        verify(brandRepository, never()).save(any(Brand.class));
+        verify(brandRepository).save(any(Brand.class));
     }
 
     @Test

--- a/src/test/java/org/service/brandcody/unit/ProductServiceTest.java
+++ b/src/test/java/org/service/brandcody/unit/ProductServiceTest.java
@@ -99,7 +99,6 @@ public class ProductServiceTest {
         newProduct.setId(2L);
 
         when(brandRepository.findById(brandId)).thenReturn(Optional.of(brand));
-        when(productRepository.findByBrandIdAndCategory(brandId, category)).thenReturn(Optional.empty());
         when(productRepository.save(any(Product.class))).thenReturn(newProduct);
 
         // When
@@ -112,7 +111,6 @@ public class ProductServiceTest {
         assertThat(result.getPrice()).isEqualTo(price);
         assertThat(result.getBrand()).isEqualTo(brand);
         verify(brandRepository).findById(brandId);
-        verify(productRepository).findByBrandIdAndCategory(brandId, category);
         verify(productRepository).save(any(Product.class));
     }
 
@@ -125,15 +123,14 @@ public class ProductServiceTest {
         Integer price = 5000;
 
         when(brandRepository.findById(brandId)).thenReturn(Optional.of(testBrand));
-        when(productRepository.findByBrandIdAndCategory(brandId, category)).thenReturn(Optional.of(testProduct));
+        when(productRepository.save(any(Product.class))).thenThrow(new org.springframework.dao.DataIntegrityViolationException("Duplicate entry"));
 
         // When & Then
         assertThatThrownBy(() -> productService.createProduct(brandId, category, price))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Product already exists for this brand and category");
         verify(brandRepository).findById(brandId);
-        verify(productRepository).findByBrandIdAndCategory(brandId, category);
-        verify(productRepository, never()).save(any(Product.class));
+        verify(productRepository).save(any(Product.class));
     }
 
     @Test

--- a/src/test/resources/fixture/data.sql
+++ b/src/test/resources/fixture/data.sql
@@ -1,56 +1,56 @@
 -- 테스트용 브랜드 데이터 추가
-INSERT INTO brands (id, name) VALUES (1, 'TestA');
-INSERT INTO brands (id, name) VALUES (2, 'TestB');
-INSERT INTO brands (id, name) VALUES (3, 'TestC');
-INSERT INTO brands (id, name) VALUES (4, 'TestD');
-INSERT INTO brands (id, name) VALUES (5, 'TestE');
+INSERT INTO brands (id, name, version) VALUES (1, 'TestA', 0);
+INSERT INTO brands (id, name, version) VALUES (2, 'TestB', 0);
+INSERT INTO brands (id, name, version) VALUES (3, 'TestC', 0);
+INSERT INTO brands (id, name, version) VALUES (4, 'TestD', 0);
+INSERT INTO brands (id, name, version) VALUES (5, 'TestE', 0);
 
 -- 브랜드 TestA 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (1, 1, 'TOP', 10000);
-INSERT INTO products (id, brand_id, category, price) VALUES (2, 1, 'OUTER', 5000);
-INSERT INTO products (id, brand_id, category, price) VALUES (3, 1, 'PANTS', 4000);
-INSERT INTO products (id, brand_id, category, price) VALUES (4, 1, 'SNEAKERS', 8000);
-INSERT INTO products (id, brand_id, category, price) VALUES (5, 1, 'BAG', 2000);
-INSERT INTO products (id, brand_id, category, price) VALUES (6, 1, 'HAT', 1500);
-INSERT INTO products (id, brand_id, category, price) VALUES (7, 1, 'SOCKS', 1500);
-INSERT INTO products (id, brand_id, category, price) VALUES (8, 1, 'ACCESSORY', 2000);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (1, 1, 'TOP', 10000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (2, 1, 'OUTER', 5000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (3, 1, 'PANTS', 4000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (4, 1, 'SNEAKERS', 8000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (5, 1, 'BAG', 2000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (6, 1, 'HAT', 1500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (7, 1, 'SOCKS', 1500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (8, 1, 'ACCESSORY', 2000, 0);
 
 -- 브랜드 TestB 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (9, 2, 'TOP', 9000);
-INSERT INTO products (id, brand_id, category, price) VALUES (10, 2, 'OUTER', 5500);
-INSERT INTO products (id, brand_id, category, price) VALUES (11, 2, 'PANTS', 3500);
-INSERT INTO products (id, brand_id, category, price) VALUES (12, 2, 'SNEAKERS', 9000);
-INSERT INTO products (id, brand_id, category, price) VALUES (13, 2, 'BAG', 2200);
-INSERT INTO products (id, brand_id, category, price) VALUES (14, 2, 'HAT', 1800);
-INSERT INTO products (id, brand_id, category, price) VALUES (15, 2, 'SOCKS', 1800);
-INSERT INTO products (id, brand_id, category, price) VALUES (16, 2, 'ACCESSORY', 2100);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (9, 2, 'TOP', 9000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (10, 2, 'OUTER', 5500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (11, 2, 'PANTS', 3500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (12, 2, 'SNEAKERS', 9000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (13, 2, 'BAG', 2200, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (14, 2, 'HAT', 1800, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (15, 2, 'SOCKS', 1800, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (16, 2, 'ACCESSORY', 2100, 0);
 
 -- 브랜드 TestC 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (17, 3, 'TOP', 9500);
-INSERT INTO products (id, brand_id, category, price) VALUES (18, 3, 'OUTER', 6000);
-INSERT INTO products (id, brand_id, category, price) VALUES (19, 3, 'PANTS', 3000);
-INSERT INTO products (id, brand_id, category, price) VALUES (20, 3, 'SNEAKERS', 8500);
-INSERT INTO products (id, brand_id, category, price) VALUES (21, 3, 'BAG', 2500);
-INSERT INTO products (id, brand_id, category, price) VALUES (22, 3, 'HAT', 1600);
-INSERT INTO products (id, brand_id, category, price) VALUES (23, 3, 'SOCKS', 2000);
-INSERT INTO products (id, brand_id, category, price) VALUES (24, 3, 'ACCESSORY', 1900);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (17, 3, 'TOP', 9500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (18, 3, 'OUTER', 6000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (19, 3, 'PANTS', 3000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (20, 3, 'SNEAKERS', 8500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (21, 3, 'BAG', 2500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (22, 3, 'HAT', 1600, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (23, 3, 'SOCKS', 2000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (24, 3, 'ACCESSORY', 1900, 0);
 
 -- 브랜드 TestD 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (25, 4, 'TOP', 11000);
-INSERT INTO products (id, brand_id, category, price) VALUES (26, 4, 'OUTER', 4800);
-INSERT INTO products (id, brand_id, category, price) VALUES (27, 4, 'PANTS', 3200);
-INSERT INTO products (id, brand_id, category, price) VALUES (28, 4, 'SNEAKERS', 9500);
-INSERT INTO products (id, brand_id, category, price) VALUES (29, 4, 'BAG', 1800);
-INSERT INTO products (id, brand_id, category, price) VALUES (30, 4, 'HAT', 1400);
-INSERT INTO products (id, brand_id, category, price) VALUES (31, 4, 'SOCKS', 1600);
-INSERT INTO products (id, brand_id, category, price) VALUES (32, 4, 'ACCESSORY', 1700);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (25, 4, 'TOP', 11000, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (26, 4, 'OUTER', 4800, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (27, 4, 'PANTS', 3200, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (28, 4, 'SNEAKERS', 9500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (29, 4, 'BAG', 1800, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (30, 4, 'HAT', 1400, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (31, 4, 'SOCKS', 1600, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (32, 4, 'ACCESSORY', 1700, 0);
 
 -- 브랜드 TestE 상품 데이터 추가
-INSERT INTO products (id, brand_id, category, price) VALUES (33, 5, 'TOP', 10500);
-INSERT INTO products (id, brand_id, category, price) VALUES (34, 5, 'OUTER', 5200);
-INSERT INTO products (id, brand_id, category, price) VALUES (35, 5, 'PANTS', 3800);
-INSERT INTO products (id, brand_id, category, price) VALUES (36, 5, 'SNEAKERS', 8800);
-INSERT INTO products (id, brand_id, category, price) VALUES (37, 5, 'BAG', 2100);
-INSERT INTO products (id, brand_id, category, price) VALUES (38, 5, 'HAT', 1700);
-INSERT INTO products (id, brand_id, category, price) VALUES (39, 5, 'SOCKS', 1900);
-INSERT INTO products (id, brand_id, category, price) VALUES (40, 5, 'ACCESSORY', 2000);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (33, 5, 'TOP', 10500, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (34, 5, 'OUTER', 5200, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (35, 5, 'PANTS', 3800, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (36, 5, 'SNEAKERS', 8800, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (37, 5, 'BAG', 2100, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (38, 5, 'HAT', 1700, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (39, 5, 'SOCKS', 1900, 0);
+INSERT INTO products (id, brand_id, category, price, version) VALUES (40, 5, 'ACCESSORY', 2000, 0);

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -3,7 +3,8 @@ DROP TABLE IF EXISTS brands;
 
 CREATE TABLE brands (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(255) NOT NULL UNIQUE
+    name VARCHAR(255) NOT NULL UNIQUE,
+    version BIGINT DEFAULT 0 NOT NULL
 );
 
 CREATE TABLE products (
@@ -11,6 +12,7 @@ CREATE TABLE products (
     brand_id BIGINT NOT NULL,
     category VARCHAR(30) NOT NULL,
     price INT NOT NULL,
+    version BIGINT DEFAULT 0 NOT NULL,
     FOREIGN KEY (brand_id) REFERENCES brands(id),
     CONSTRAINT uk_brand_category UNIQUE (brand_id, category)
 );


### PR DESCRIPTION
### 낙관적 락 및 재시도 로직 추가
- 엔티티 레벨 낙관적 락 적용 (@Version 어노테이션 도입)
    - Brand 및 Product 엔티티에 버전 필드 추가
    - 동시 수정 시 버전 불일치 감지 및 예외 발생
- Spring Retry 재시도 메커니즘 구현
    - 낙관적 락 충돌 발생 시 자동 재시도
    - 재시도 정책 설정 (최대 3회, 500ms 지연)
- 유니크 제약조건을 활용한 동시 생성 처리
    - 브랜드-카테고리 중복 생성 방지
    - 트랜잭션 경계 최적화
 ### 오류 처리 개선 및 동시성 관련 테스트 코드 추가
- 오류 처리 개선 
   - DataIntegrityViolationException 처리 (유니크 제약조건 위반)
   - ObjectOptimisticLockingFailureException 처리 (낙관적 락 충돌)
 - 동시성 시나리오 테스트 추가
   - 낙관적 락 예외 발생 및 재시도 검증
   - 동일 브랜드-카테고리 동시 생성 시나리오 테스트
   - 병렬 상품 가격 업데이트 성공 검증